### PR TITLE
Address review comments

### DIFF
--- a/src/GnosisDAppNodeIncentiveV2Deployer.sol
+++ b/src/GnosisDAppNodeIncentiveV2Deployer.sol
@@ -175,7 +175,7 @@ contract GnosisDAppNodeIncentiveV2Deployer is Ownable {
         bytes calldata signatures,
         bytes32[] calldata deposit_data_roots
     ) internal {
-        User storage user = users[msg.sender];
+        User storage user = users[benefactor];
         // Only allow a registered user to submit deposits
         require(address(user.safe) != address(0), "not registered");
         // Sanity check lengths, allow to submit less deposits in case MaxEB activates early

--- a/src/GnosisDAppNodeIncentiveV2Deployer.sol
+++ b/src/GnosisDAppNodeIncentiveV2Deployer.sol
@@ -245,7 +245,7 @@ contract GnosisDAppNodeIncentiveV2Deployer is Ownable, Claimable {
     function clearPendingDeposits(address benefactor) external onlyOwner {
         User storage user = users[benefactor];
         require(address(user.safe) != address(0), "not registered");
-        require(user.status != Status.Pending, "already pending");
+        require(user.status == Status.Submitted, "not submitted");
         user.status = Status.Pending;
         delete user.pendingDeposits;
     }

--- a/src/GnosisDAppNodeIncentiveV2Deployer.sol
+++ b/src/GnosisDAppNodeIncentiveV2Deployer.sol
@@ -8,9 +8,10 @@ import "./GnosisDAppNodeIncentiveV2SafeModuleSetup.sol";
 import "./GnosisDAppNodeIncentiveV2SafeModule.sol";
 import "./utils/ISBCDepositContract.sol";
 import "./utils/Ownable.sol";
+import "./utils/Claimable.sol";
 import "./utils/IERC20.sol";
 
-contract GnosisDAppNodeIncentiveV2Deployer is Ownable {
+contract GnosisDAppNodeIncentiveV2Deployer is Ownable, Claimable {
     enum Status {
         Pending,
         Submitted,
@@ -247,5 +248,15 @@ contract GnosisDAppNodeIncentiveV2Deployer is Ownable {
         require(user.status != Status.Pending, "already pending");
         user.status = Status.Pending;
         delete user.pendingDeposits;
+    }
+
+    /**
+     * @dev Allows to transfer any locked token from this contract.
+     * Only owner can call this method.
+     * @param _token address of the token, if it is not provided (0x00..00), native coins will be transferred.
+     * @param _to address that will receive the locked tokens from this contract.
+     */
+    function claimTokens(address _token, address _to) external onlyOwner {
+        _claimValues(_token, _to);
     }
 }

--- a/src/utils/Claimable.sol
+++ b/src/utils/Claimable.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: CC0-1.0
+
+pragma solidity ^0.8.13;
+
+import {IERC20} from "./IERC20.sol";
+
+/**
+ * @title Claimable
+ * @dev Implementation of the claiming utils that can be useful for withdrawing accidentally sent tokens.
+ */
+contract Claimable {
+    /**
+     * @dev Withdraws the erc20 tokens or native coins from this contract.
+     * @param _token address of the claimed token or address(0) for native coins.
+     * @param _to address of the tokens/coins receiver.
+     */
+    function _claimValues(address _token, address _to) internal {
+        if (_token == address(0)) {
+            _claimNativeCoins(_to);
+        } else {
+            _claimERC20Tokens(_token, _to);
+        }
+    }
+
+    /**
+     * @dev Internal function for withdrawing all native coins from the contract.
+     * @param _to address of the coins receiver.
+     */
+    function _claimNativeCoins(address _to) internal {
+        uint256 balance = address(this).balance;
+        payable(_to).transfer(balance);
+    }
+
+    /**
+     * @dev Internal function for withdrawing all tokens of some particular ERC20 contract from this contract.
+     * @param _token address of the claimed ERC20 token.
+     * @param _to address of the tokens receiver.
+     */
+    function _claimERC20Tokens(address _token, address _to) internal {
+        uint256 balance = IERC20(_token).balanceOf(address(this));
+        IERC20(_token).transfer(_to, balance);
+    }
+}


### PR DESCRIPTION
> I believe this: User storage user = users[msg.sender]; should be User storage user = users[benefactor]; otherwise submitPendingDepositsFor couldn't work and it's also rare that you have defined the variable Benefactor in the function call but it isn't used

https://github.com/dapplion/gno_incentive_v2/commit/4a5e1cdba168bc5a3a9c430ed24c245700d1d6ce

> Maybe also make an owner function to claim ether/GNOs?¿ from the Deployer in case we need to migrate the program for some reason

https://github.com/dapplion/gno_incentive_v2/commit/8f61185b177775635c8dbd0dd56f17057a9c4444

> On clearPendingDeposits if the status is Executed it doesn’t make sense to allow the clear

https://github.com/dapplion/gno_incentive_v2/pull/2/commits/0d624bdb62c85cf486c6f1a9b04edfb732414bce